### PR TITLE
Fix error "consider removing `.into_iter()`"

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -295,7 +295,7 @@ enum Command {
     Init(InitCommandHandler<Stdout>),
 }
 
-impl str::FromStr for Command {
+impl FromStr for Command {
     type Err = anyhow::Error;
 
     fn from_str(input: &str) -> Result<Command, Self::Err> {
@@ -342,7 +342,7 @@ impl<'a> CommandHandler<'a> for AddCommandHandler {
 
         // process bindings
         let btp = BindingProcessor::new(&bindings_home, binding_type, binding_name, confirmer);
-        btp.add_bindings(binding_key_vals.unwrap().into_iter().map(|s| s.as_str()))
+        btp.add_bindings(binding_key_vals.unwrap().map(|s| s.as_str()))
     }
 }
 
@@ -587,7 +587,7 @@ mod tests {
     #[serial(requires_cwd)]
     fn given_no_bindings_root_set_it_returns_current_working_directory() {
         temp_env::with_var_unset("SERVICE_BINDING_ROOT", || {
-            let root = super::service_binding_root();
+            let root = service_binding_root();
             assert!(root.starts_with(env::current_dir().unwrap().to_str().unwrap()));
         });
     }
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     fn given_bindings_root_set_it_returns_bindings_root_dir() {
         temp_env::with_var("SERVICE_BINDING_ROOT", Some("/bindings"), || {
-            let root = super::service_binding_root();
+            let root = service_binding_root();
             assert!(root.starts_with("/bindings"));
         });
     }


### PR DESCRIPTION
* during a build, one could see:

```
Run actions-rs/cargo@v1
/home/runner/.cargo/bin/cargo clippy -- -D warnings
    Checking binding_tool v1.17.0 (/home/runner/work/binding-tool/binding-tool)
error: useless conversion to the same type: `clap::parser::ValuesRef<'_, std::string::String>`
Error:    --> src/command.rs:345:26
    |
345 |         btp.add_bindings(binding_key_vals.unwrap().into_iter().map(|s| s.as_str()))
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `binding_key_vals.unwrap()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`

error: could not compile `binding_tool` due to previous error
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```

* also fix "unnecessary qualification" warnings