### PR TITLE
Support download dependencies from a specific buildpack version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The binding-tool uses rustls and rustls-native-certs, which will read CA certifi
 
 1. Create dependency mappings and download dependencies for all dependencies in a buildpack: `bt dependency-mapping -b paketo-buildpacks/bellsoft-liberica`
 2. Run again with a second buildpack. It'll update the dependency mappings and download dependencies. You can even use `dm` for short. `bt dm -b paketo-buildpacks/apache-tomcat`.
-3. If you have the `buildpack.toml` file locally, you can `bt dm -t path/to/buildpack.toml` and it will download all dependencies from that file and create dependency mappings for them.
+3. You may download from a specific version of a buildpack using `bt dm -b paketo-buildpacks/syft@v1.24.1`.
+4. If you have the `buildpack.toml` file locally, you can `bt dm -t path/to/buildpack.toml` and it will download all dependencies from that file and create dependency mappings for them.
 
 ### Creating CA Certificate Bindings
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -283,7 +283,8 @@ impl Parser {
                             .value_name("buildpack")
                             .action(ArgAction::Append)
                             .conflicts_with("TOML")
-                            .help("buildpack ID from which dependencies will be loaded"),
+                            .help("buildpack ID and optional version from which dependencies will be loaded\n    \
+                                Example: `buildpack/id@version` or `buildpack/id`"),
                     )
                     .about("Convenience for adding `dependency-mapping` bindings")
                     .after_help(include_str!("help/additional_help_binding.txt")),

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -82,7 +82,13 @@ pub(super) fn parse_buildpack_toml_from_disk(path: &path::Path) -> Result<Vec<De
 }
 
 pub(super) fn parse_buildpack_toml_from_network(buildpack: &str) -> Result<Vec<Dependency>> {
-    let uri = format!("https://raw.githubusercontent.com/{buildpack}/main/buildpack.toml");
+    let parts = buildpack.splitn(2, '@').collect::<Vec<&str>>();
+
+    let uri = match parts.as_slice() {
+        [b] => Ok(format!("https://raw.githubusercontent.com/{b}/main/buildpack.toml")),
+        [b, v] => Ok(format!("https://raw.githubusercontent.com/{b}/{v}/buildpack.toml")),
+        [..] => Err(anyhow!("parse of [{buildpack}], should have format `buildpack/id@version`, `@version` is optional")),
+    }?;
 
     let agent = configure_agent()?;
     let res = agent


### PR DESCRIPTION
Resolves #34

You may now specify a buildpack as either `buildpack/id` or `buildpack/id@version`.

If you include an `@version`, the `@` is stripped out and `version` is sent to GitHub as a version tag.

For example, to fetch from the Syft buildpack version 1.24.1 use `bt dm -b paketo-buildpacks/syft@v1.24.1`.