### PR TITLE
Fix timeouts & document settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ To enable proxy support simply set `PROXY=http://localhost:8080` and insert your
 
 The binding-tool uses rustls and rustls-native-certs, which will read CA certificates from the local system store. The CLI reads TLS certificates from the local system store, so if you need to add or trust additional certificates you can just add them to your OS and the tool will pick them up automatically. If you do not or cannot add the certificate to the system store, you may set `SSL_CERT_FILE` and point it to a PEM encoded CA certs file which will be trusted instead.
 
+## Client Download Settings
+
+You may configure the following client download settings. These impact how the client operates when downloading dependencies.
+
+| Env Variable        | Default   | Description                                                                                                                                                |
+| ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BT_MAX_SIMULTANEOUS | 5         | The maximum number of simultaneous downloads                                                                                                               |
+| BT_CONN_TIMEOUT     | 5         | Timeout for the socket connection to be successful                                                                                                         |
+| BT_READ_TIMEOUT     | 5         | Timeout for the individual reads of the socket                                                                                                             |
+| BT_REQ_TIMEOUT      | <not-set> | Timeout for the overall request, including DNS resolution, connection time, redirects, and reading the response body. If set, overrides `BT_READ_TIMEOUT`. |
+
 ## Examples
 
 ### Creating Dependency Mapping Bindings


### PR DESCRIPTION
Fixes the usage of timeouts with the download client. Previously, a timeout on the entire request was being set to 30s. In some cases, you could go over this timeout and it would cause a download failure. Now the default timeouts are a connection timeout of 5secs and a read timeout of 5secs. This means that you have up to 5 seconds to make a TCP connection and you have up to 5 seconds for each individual read on the socket.

For backward compatibility, you may still configure the `BT_REQ_TIMEOUT` value which will set the overall request timeout. This is not recommended though. It defaults to being unset, which does not enforce an overall timeout on the request.

In addition, this commit includes documentation for each of the environment variables you can set to configure the client.

Resolves #3.