### PR TITLE
chore: allow digest updates without release timestamp

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,8 @@
     {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["digest"],
-      "dependencyDashboardApproval": true
+      "dependencyDashboardApproval": true,
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     }
   ]
 }


### PR DESCRIPTION
Sets `minimumReleaseAgeBehaviour: timestamp-optional` for GitHub Actions digest updates so the `renovate/stability-days` check no longer leaves them pending forever. Digest updates remain gated behind dependency dashboard approval.